### PR TITLE
Refactor param names and tests

### DIFF
--- a/src/main/java/uk/gov/companieshouse/ocrapiconsumer/request/OcrApiConsumerController.java
+++ b/src/main/java/uk/gov/companieshouse/ocrapiconsumer/request/OcrApiConsumerController.java
@@ -19,9 +19,9 @@ import uk.gov.companieshouse.ocrapiconsumer.common.ErrorResponseDTO;
 public class OcrApiConsumerController {
 
     private static final String REQUEST_ENDPOINT = "/ocr-requests";
-    private static final String EXTERNAL_REFERENCE_ID_PARAMETER_NAME = "external-reference-id";
-    private static final String IMAGE_ENDPOINT_PARAMETER_NAME = "image-endpoint";
-    private static final String EXTRACTED_TEXT_ENDPOINT = "extracted-text-endpoint";
+    private static final String IMAGE_ENDPOINT_PARAMETER_NAME = "image_endpoint";
+    private static final String CONVERTED_TEXT_ENDPOINT_PARAMETER_NAME = "converted_text_endpoint";
+    private static final String RESPONSE_ID_PARAMETER_NAME = "response_id";
 
     private static final String CONTROLLER_ERROR_MESSAGE = "Unexpected error occurred";
     private static final String CLIENT_ERROR_MESSAGE = "A client error has occurred during the request";
@@ -40,17 +40,17 @@ public class OcrApiConsumerController {
      * Receives an OCR request from CHIPS and calls the service to:
      * - log it asynchronously
      * - return status code 202 (ACCEPTED)
-     * @param   externalReferenceID       The request reference ID
      * @param   imageEndpoint             The endpoint that the image is located at
-     * @param   extractedTextEndpoint     The endpoint to send the converted text to
+     * @param   convertedTextEndpoint     The endpoint to send the converted text to
+     * @param   responseId                The response ID of the request
      * @return                            The HTTP Status code 202 ACCEPTED
      */
     @PostMapping(REQUEST_ENDPOINT)
-    public ResponseEntity<HttpStatus> receiveOcrRequest(@RequestParam(EXTERNAL_REFERENCE_ID_PARAMETER_NAME) String externalReferenceID,
-                                                @RequestParam(IMAGE_ENDPOINT_PARAMETER_NAME) String imageEndpoint,
-                                                @RequestParam(EXTRACTED_TEXT_ENDPOINT) String extractedTextEndpoint) {
+    public ResponseEntity<HttpStatus> receiveOcrRequest(@RequestParam(IMAGE_ENDPOINT_PARAMETER_NAME) String imageEndpoint,
+                                                        @RequestParam(CONVERTED_TEXT_ENDPOINT_PARAMETER_NAME) String convertedTextEndpoint,
+                                                        @RequestParam(RESPONSE_ID_PARAMETER_NAME) String responseId) {
 
-        service.logOcrRequest(externalReferenceID, imageEndpoint, extractedTextEndpoint);
+        service.logOcrRequest(imageEndpoint, convertedTextEndpoint, responseId);
         return new ResponseEntity<>(HttpStatus.ACCEPTED);
     }
 

--- a/src/main/java/uk/gov/companieshouse/ocrapiconsumer/request/OcrApiConsumerService.java
+++ b/src/main/java/uk/gov/companieshouse/ocrapiconsumer/request/OcrApiConsumerService.java
@@ -26,35 +26,35 @@ public class OcrApiConsumerService {
     }
 
     @Async
-    public void logOcrRequest(String externalReferenceID, String imageEndpoint, String extractedTextEndpoint) {
-        LOG.infoContext(externalReferenceID,
-                String.format("Request received with ID: %s, Image Endpoint: %s, Extracted Text Endpoint: %s",
-                        externalReferenceID, imageEndpoint, extractedTextEndpoint),
+    public void logOcrRequest(String imageEndpoint, String convertedTextEndpoint, String responseId) {
+        LOG.infoContext(responseId,
+                String.format("Request received with Image Endpoint: %s, Extracted Text Endpoint: %s",
+                        imageEndpoint, convertedTextEndpoint),
                 null);
 
-        LOG.debugContext(externalReferenceID, "Getting the TIFF image", null);
+        LOG.debugContext(responseId, "Getting the TIFF image", null);
         byte[] image = getTiffImage(imageEndpoint);
 
-        LOG.debugContext(externalReferenceID, "Sending image to ocr microservice for conversion", null);
+        LOG.debugContext(responseId, "Sending image to ocr microservice for conversion", null);
 
-        ResponseEntity<ExtractTextResultDTO> response = sendRequestToOcrMicroservice(externalReferenceID, image);
+        ResponseEntity<ExtractTextResultDTO> response = sendRequestToOcrMicroservice(image, responseId);
 
         ExtractTextResultDTO extractedText = null;
         if(response != null) {
             extractedText = response.getBody();
         }
 
-        LOG.debugContext(externalReferenceID,
+        LOG.debugContext(responseId,
                 "Sending the extracted text response for the articles of association", null);
-        sendTextResult(extractedTextEndpoint, extractedText);
+        sendTextResult(convertedTextEndpoint, extractedText);
     }
 
     private byte[] getTiffImage(String imageEndpoint) {
         return chipsImageAdapter.getTiffImageFromChips(imageEndpoint);
     }
 
-    private ResponseEntity<ExtractTextResultDTO> sendRequestToOcrMicroservice(String externalReferenceID, byte[] image) {
-        return ocrApiRequestAdapter.sendOcrRequestToOcrApi(externalReferenceID, image);
+    private ResponseEntity<ExtractTextResultDTO> sendRequestToOcrMicroservice(byte[] image, String responseId) {
+        return ocrApiRequestAdapter.sendOcrRequestToOcrApi(image, responseId);
 
     }
 

--- a/src/main/java/uk/gov/companieshouse/ocrapiconsumer/request/OcrApiRequestAdapter.java
+++ b/src/main/java/uk/gov/companieshouse/ocrapiconsumer/request/OcrApiRequestAdapter.java
@@ -28,18 +28,18 @@ public class OcrApiRequestAdapter {
 
     /**
      * Sends the OCR request to the ocr-api
-     * @param   externalReferenceID   The request ID.
      * @param   tiffContent           The image content retrieved from CHIPS.
+     * @param   responseId            The request ID.
      * @return  A response entity containing the extracted text result DTO.
      */
-    public ResponseEntity<ExtractTextResultDTO> sendOcrRequestToOcrApi(String externalReferenceID, byte[] tiffContent) {
+    public ResponseEntity<ExtractTextResultDTO> sendOcrRequestToOcrApi(byte[] tiffContent, String responseId) {
         String ocrApiUrl = readOcrApiUrlFromEnv();
 
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.MULTIPART_FORM_DATA);
 
         // Filename is required to send the byte array as a file to the MultipartFile parameter.
-        String filename = externalReferenceID + ".tif";
+        String filename = responseId + ".tif";
         ByteArrayResource byteArrayResource = new ByteArrayResource(tiffContent) {
             @Override
             public String getFilename() {
@@ -49,7 +49,7 @@ public class OcrApiRequestAdapter {
 
         MultiValueMap<String, Object> params = new LinkedMultiValueMap<>();
         params.add(FILE_REQUEST_PARAMETER_NAME, byteArrayResource);
-        params.add(RESPONSE_ID_REQUEST_PARAMETER_NAME, externalReferenceID);
+        params.add(RESPONSE_ID_REQUEST_PARAMETER_NAME, responseId);
 
         HttpEntity<MultiValueMap<String, Object>> entity = new HttpEntity<>(params, headers);
 

--- a/src/test/java/uk/gov/companieshouse/ocrapiconsumer/IntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/ocrapiconsumer/IntegrationTest.java
@@ -19,9 +19,9 @@ import uk.gov.companieshouse.ocrapiconsumer.request.TestParent;
 @SpringBootTest(classes = OcrApiConsumerApplication.class, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class IntegrationTest extends TestParent {
 
-    private static final String EXTERNAL_REFERENCE_ID_PARAM_NAME = "external-reference-id";
-    private static final String IMAGE_ENDPOINT_PARAM_NAME = "image-endpoint";
-    private static final String EXTRACTED_TEXT_ENDPOINT_PARAM_NAME = "extracted-text-endpoint";
+    private static final String IMAGE_ENDPOINT_PARAM_NAME = "image_endpoint";
+    private static final String CONVERTED_TEXT_ENDPOINT_PARAM_NAME = "converted_text_endpoint";
+    private static final String RESPONSE_ID_PARAM_NAME = "response_id";
     private static final String APPLICATION_URL = "/ocr-requests";
 
     @LocalServerPort
@@ -35,9 +35,9 @@ class IntegrationTest extends TestParent {
         var expected = HttpStatus.ACCEPTED;
 
         MultiValueMap<String, Object> params = new LinkedMultiValueMap<>();
-        params.add(EXTERNAL_REFERENCE_ID_PARAM_NAME, EXTERNAL_REFERENCE_ID);
         params.add(IMAGE_ENDPOINT_PARAM_NAME, IMAGE_ENDPOINT);
-        params.add(EXTRACTED_TEXT_ENDPOINT_PARAM_NAME, EXTRACTED_TEXT_ENDPOINT);
+        params.add(CONVERTED_TEXT_ENDPOINT_PARAM_NAME, CONVERTED_TEXT_ENDPOINT);
+        params.add(RESPONSE_ID_PARAM_NAME, RESPONSE_ID);
 
         var uri = "http://localhost:" + port + APPLICATION_URL;
 
@@ -51,7 +51,7 @@ class IntegrationTest extends TestParent {
     void verifyControllerThrowsRestClientExceptionWhenRequiredParameterMissing() {
 
         MultiValueMap<String, Object> params = new LinkedMultiValueMap<>();
-        params.add(EXTERNAL_REFERENCE_ID_PARAM_NAME, EXTERNAL_REFERENCE_ID);
+        params.add(RESPONSE_ID_PARAM_NAME, RESPONSE_ID);
         params.add(IMAGE_ENDPOINT_PARAM_NAME, IMAGE_ENDPOINT);
         // no extracted text endpoint parameter which is a required parameter
 

--- a/src/test/java/uk/gov/companieshouse/ocrapiconsumer/request/ChipsExtractedTextAdapterTest.java
+++ b/src/test/java/uk/gov/companieshouse/ocrapiconsumer/request/ChipsExtractedTextAdapterTest.java
@@ -29,25 +29,19 @@ class ChipsExtractedTextAdapterTest extends TestParent {
 
     @BeforeEach
     void setupTests() {
-        extractTextResultDTO = new ExtractTextResultDTO();
-        extractTextResultDTO.setResponseId(EXTERNAL_REFERENCE_ID);
-        extractTextResultDTO.setLowestConfidenceScore(LOWEST_CONFIDENCE_SCORE);
-        extractTextResultDTO.setAverageConfidenceScore(AVERAGE_CONFIDENCE_SCORE);
-        extractTextResultDTO.setExtractedText(EXTRACTED_TEXT);
-        extractTextResultDTO.setOcrProcessingTimeMs(OCR_PROCESSING_TIME);
-        extractTextResultDTO.setTotalProcessingTimeMs(TOTAL_PROCESSING_TIME);
+        extractTextResultDTO = createMockTextResult();
     }
 
     @Test
     void testSendExtractedTextSuccessfully() {
         // given
-        when(restTemplate.postForEntity(eq(EXTRACTED_TEXT_ENDPOINT), any(), any()))
+        when(restTemplate.postForEntity(eq(CONVERTED_TEXT_ENDPOINT), any(), any()))
                 .thenReturn(new ResponseEntity<>(HttpStatus.OK));
 
         // when
-        chipsExtractedTextAdapter.sendTextResult(EXTRACTED_TEXT_ENDPOINT, extractTextResultDTO);
+        chipsExtractedTextAdapter.sendTextResult(CONVERTED_TEXT_ENDPOINT, extractTextResultDTO);
 
         // then
-        verify(restTemplate).postForEntity(eq(EXTRACTED_TEXT_ENDPOINT), any(), any());
+        verify(restTemplate).postForEntity(eq(CONVERTED_TEXT_ENDPOINT), any(), any());
     }
 }

--- a/src/test/java/uk/gov/companieshouse/ocrapiconsumer/request/OcrApiConsumerControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/ocrapiconsumer/request/OcrApiConsumerControllerTest.java
@@ -29,10 +29,10 @@ class OcrApiConsumerControllerTest extends TestParent {
 
         // when
         var actual = controller
-                .receiveOcrRequest(EXTERNAL_REFERENCE_ID,IMAGE_ENDPOINT, EXTRACTED_TEXT_ENDPOINT);
+                .receiveOcrRequest(IMAGE_ENDPOINT, CONVERTED_TEXT_ENDPOINT, RESPONSE_ID);
 
         // then
-        verify(service).logOcrRequest(EXTERNAL_REFERENCE_ID, IMAGE_ENDPOINT, EXTRACTED_TEXT_ENDPOINT);
+        verify(service).logOcrRequest(IMAGE_ENDPOINT, CONVERTED_TEXT_ENDPOINT, RESPONSE_ID);
         assertThat(actual, is(expected));
     }
 }

--- a/src/test/java/uk/gov/companieshouse/ocrapiconsumer/request/OcrApiConsumerServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/ocrapiconsumer/request/OcrApiConsumerServiceTest.java
@@ -30,13 +30,7 @@ class OcrApiConsumerServiceTest extends TestParent {
 
     @BeforeEach
     void setupTests() {
-        extractTextResultDTO = new ExtractTextResultDTO();
-        extractTextResultDTO.setResponseId(EXTERNAL_REFERENCE_ID);
-        extractTextResultDTO.setLowestConfidenceScore(LOWEST_CONFIDENCE_SCORE);
-        extractTextResultDTO.setAverageConfidenceScore(AVERAGE_CONFIDENCE_SCORE);
-        extractTextResultDTO.setExtractedText(EXTRACTED_TEXT);
-        extractTextResultDTO.setOcrProcessingTimeMs(OCR_PROCESSING_TIME);
-        extractTextResultDTO.setTotalProcessingTimeMs(TOTAL_PROCESSING_TIME);
+        extractTextResultDTO = createMockTextResult();
         response = new ResponseEntity<>(extractTextResultDTO, HttpStatus.CREATED);
     }
 
@@ -44,14 +38,14 @@ class OcrApiConsumerServiceTest extends TestParent {
     void testOcrApiServiceLogsSuccessfully() {
         // given
         when(chipsImageAdapter.getTiffImageFromChips(IMAGE_ENDPOINT)).thenReturn(MOCK_TIFF_CONTENT);
-        when(ocrApiRequestAdapter.sendOcrRequestToOcrApi(EXTERNAL_REFERENCE_ID, MOCK_TIFF_CONTENT)).thenReturn(response);
+        when(ocrApiRequestAdapter.sendOcrRequestToOcrApi(MOCK_TIFF_CONTENT, RESPONSE_ID)).thenReturn(response);
 
         // when
-        ocrApiConsumerService.logOcrRequest(EXTERNAL_REFERENCE_ID, IMAGE_ENDPOINT, EXTRACTED_TEXT_ENDPOINT);
+        ocrApiConsumerService.logOcrRequest(IMAGE_ENDPOINT, CONVERTED_TEXT_ENDPOINT, RESPONSE_ID);
 
         // then
         verify(chipsImageAdapter).getTiffImageFromChips(IMAGE_ENDPOINT);
-        verify(ocrApiRequestAdapter).sendOcrRequestToOcrApi(EXTERNAL_REFERENCE_ID, MOCK_TIFF_CONTENT);
-        verify(chipsExtractedTextAdapter).sendTextResult(EXTRACTED_TEXT_ENDPOINT, extractTextResultDTO);
+        verify(ocrApiRequestAdapter).sendOcrRequestToOcrApi(MOCK_TIFF_CONTENT, RESPONSE_ID);
+        verify(chipsExtractedTextAdapter).sendTextResult(CONVERTED_TEXT_ENDPOINT, extractTextResultDTO);
     }
 }

--- a/src/test/java/uk/gov/companieshouse/ocrapiconsumer/request/OcrApiRequestAdapterTest.java
+++ b/src/test/java/uk/gov/companieshouse/ocrapiconsumer/request/OcrApiRequestAdapterTest.java
@@ -41,7 +41,7 @@ class OcrApiRequestAdapterTest extends TestParent {
 
         // when
         ResponseEntity<ExtractTextResultDTO> actual = ocrApiRequestAdapter
-                .sendOcrRequestToOcrApi(EXTERNAL_REFERENCE_ID, MOCK_TIFF_CONTENT);
+                .sendOcrRequestToOcrApi(MOCK_TIFF_CONTENT, RESPONSE_ID);
 
         // then
         assertThat(actual, is(expected));

--- a/src/test/java/uk/gov/companieshouse/ocrapiconsumer/request/TestParent.java
+++ b/src/test/java/uk/gov/companieshouse/ocrapiconsumer/request/TestParent.java
@@ -3,9 +3,9 @@ package uk.gov.companieshouse.ocrapiconsumer.request;
 import org.springframework.http.ResponseEntity;
 
 public class TestParent {
-    protected static final String EXTERNAL_REFERENCE_ID = "ABC";
+    protected static final String RESPONSE_ID = "ABC";
     protected static final String IMAGE_ENDPOINT = "https://image-endpoint";
-    protected static final String EXTRACTED_TEXT_ENDPOINT = "https://extracted-text-endpoint";
+    protected static final String CONVERTED_TEXT_ENDPOINT = "https://converted-text-endpoint";
     protected static final byte[] MOCK_TIFF_CONTENT = {0, 1, 2};
     protected static final String EXTRACTED_TEXT = "Mock converted text";
     protected static final long OCR_PROCESSING_TIME = 100L;
@@ -17,7 +17,7 @@ public class TestParent {
 
     protected ExtractTextResultDTO createMockTextResult() {
         ExtractTextResultDTO extractTextResultDTO = new ExtractTextResultDTO();
-        extractTextResultDTO.setResponseId(EXTERNAL_REFERENCE_ID);
+        extractTextResultDTO.setResponseId(RESPONSE_ID);
         extractTextResultDTO.setLowestConfidenceScore(LOWEST_CONFIDENCE_SCORE);
         extractTextResultDTO.setAverageConfidenceScore(AVERAGE_CONFIDENCE_SCORE);
         extractTextResultDTO.setExtractedText(EXTRACTED_TEXT);


### PR DESCRIPTION
Fixes the endpoint names for the controller to use correct specification of names and snake case
Update unit tests to reflect these changes and also use TestParent class method for initialising mock ExtractedTextResultDTO