### PR TITLE
Refactor endpoint paths to use internal and added healthcheck test

### DIFF
--- a/routes.yaml
+++ b/routes.yaml
@@ -3,3 +3,4 @@ group: internalapi
 weight: 929
 routes:
    1: ^/internal/ocr-requests
+   2: ^/internal/ocr-api-consumer/healthcheck

--- a/src/main/java/uk/gov/companieshouse/ocrapiconsumer/healthcheck/HealthCheckController.java
+++ b/src/main/java/uk/gov/companieshouse/ocrapiconsumer/healthcheck/HealthCheckController.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class HealthCheckController {
 
-    @GetMapping("/healthcheck")
+    @GetMapping("/internal/ocr-api-consumer/healthcheck")
     public ResponseEntity<String> isHealthy() {
         return new ResponseEntity<>("ALIVE", HttpStatus.OK);
     }

--- a/src/main/java/uk/gov/companieshouse/ocrapiconsumer/request/OcrApiConsumerController.java
+++ b/src/main/java/uk/gov/companieshouse/ocrapiconsumer/request/OcrApiConsumerController.java
@@ -18,7 +18,7 @@ import uk.gov.companieshouse.ocrapiconsumer.common.ErrorResponseDTO;
 @RestController
 public class OcrApiConsumerController {
 
-    private static final String REQUEST_ENDPOINT = "/ocr-requests";
+    private static final String REQUEST_ENDPOINT = "/internal/ocr-requests";
     private static final String IMAGE_ENDPOINT_PARAMETER_NAME = "image_endpoint";
     private static final String CONVERTED_TEXT_ENDPOINT_PARAMETER_NAME = "converted_text_endpoint";
     private static final String RESPONSE_ID_PARAMETER_NAME = "response_id";

--- a/src/test/java/uk/gov/companieshouse/ocrapiconsumer/IntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/ocrapiconsumer/IntegrationTest.java
@@ -9,6 +9,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestClientException;
@@ -22,7 +23,8 @@ class IntegrationTest extends TestParent {
     private static final String IMAGE_ENDPOINT_PARAM_NAME = "image_endpoint";
     private static final String CONVERTED_TEXT_ENDPOINT_PARAM_NAME = "converted_text_endpoint";
     private static final String RESPONSE_ID_PARAM_NAME = "response_id";
-    private static final String APPLICATION_URL = "/ocr-requests";
+    private static final String APPLICATION_URL = "/internal/ocr-requests";
+    private static final String HEALTHCHECK_URL = "/internal/ocr-api-consumer/healthcheck";
 
     @LocalServerPort
     private int port;
@@ -58,6 +60,21 @@ class IntegrationTest extends TestParent {
         String uri = "http://localhost:" + port + APPLICATION_URL;
         assertThrows(RestClientException.class, () -> this.restTemplate
                 .postForEntity(uri, params, HttpStatus.class));
+    }
+
+    @Test
+    void verifyHealthCheckControllerReturns200Alive() {
+        HttpStatus expectedResponseCode = HttpStatus.OK;
+        String expectedResponseMessage = "ALIVE";
+
+        String uri = "http://localhost:" + port + HEALTHCHECK_URL;
+
+        ResponseEntity<String> response = this.restTemplate.getForEntity(uri, String.class);
+        HttpStatus actualResponseCode = response.getStatusCode();
+        String actualResponseMessage = response.getBody();
+
+        assertThat(actualResponseCode, is(expectedResponseCode));
+        assertThat(actualResponseMessage, is(expectedResponseMessage));
     }
 
 }


### PR DESCRIPTION
Refactors the endpoints of the ocr-api-consumer to use the /internal prefix.
- Refactors healthcheck to /internal/ocr-api-consumer/healthcheck
- Refactors request controller to /internal/ocr-requests
- Added sunny day healthcheck integration test
- Updated routes.yaml to use the new endpoint paths