### PR TITLE
Refactor controller to use RequestBody not RequestParam

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,12 @@
 		</dependency>
 
 		<dependency>
+			<groupId>org.hibernate</groupId>
+			<artifactId>hibernate-validator</artifactId>
+			<version>6.0.13.Final</version>
+		</dependency>
+
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>

--- a/src/main/java/uk/gov/companieshouse/ocrapiconsumer/request/OcrApiConsumerController.java
+++ b/src/main/java/uk/gov/companieshouse/ocrapiconsumer/request/OcrApiConsumerController.java
@@ -39,22 +39,22 @@ public class OcrApiConsumerController {
      * Receives an OCR request from CHIPS and calls the service to:
      * - log it asynchronously
      * - return status code 202 (ACCEPTED)
-     * @param   requestDTO  The request details sent by CHIPS.
+     * @param   ocrRequest  A request object containing the 3 mandatory JSON fields.
      * @return              The HTTP Status code 202 ACCEPTED
      */
     @PostMapping(REQUEST_ENDPOINT)
-    public ResponseEntity<HttpStatus> receiveOcrRequest(@Valid @RequestBody OcrRequest requestDTO) {
+    public ResponseEntity<HttpStatus> receiveOcrRequest(@Valid @RequestBody OcrRequest ocrRequest) {
 
-        service.logOcrRequest(requestDTO.getImageEndpoint(),
-                requestDTO.getConvertedTextEndpoint(),
-                requestDTO.getResponseId());
+        service.logOcrRequest(ocrRequest.getImageEndpoint(),
+                ocrRequest.getConvertedTextEndpoint(),
+                ocrRequest.getResponseId());
         return new ResponseEntity<>(HttpStatus.ACCEPTED);
     }
 
     @PostMapping("/internal/ocr-api-request")
-    public ResponseEntity<HttpStatus> sendTestOcrApiRequest(@Valid @RequestBody OcrRequest requestDTO) {
+    public ResponseEntity<HttpStatus> sendTestOcrApiRequest(@Valid @RequestBody OcrRequest ocrRequest) {
         String version = System.getProperty("java.version");
-        String responseId = requestDTO.getResponseId();
+        String responseId = ocrRequest.getResponseId();
         LOG.debugContext(responseId, "Java version: " + version, null);
 
         service.sendOcrApiRequest(responseId);

--- a/src/main/java/uk/gov/companieshouse/ocrapiconsumer/request/OcrApiConsumerController.java
+++ b/src/main/java/uk/gov/companieshouse/ocrapiconsumer/request/OcrApiConsumerController.java
@@ -43,7 +43,7 @@ public class OcrApiConsumerController {
      * @return              The HTTP Status code 202 ACCEPTED
      */
     @PostMapping(REQUEST_ENDPOINT)
-    public ResponseEntity<HttpStatus> receiveOcrRequest(@Valid @RequestBody OcrRequestDTO requestDTO) {
+    public ResponseEntity<HttpStatus> receiveOcrRequest(@Valid @RequestBody OcrRequest requestDTO) {
 
         service.logOcrRequest(requestDTO.getImageEndpoint(),
                 requestDTO.getConvertedTextEndpoint(),
@@ -52,7 +52,7 @@ public class OcrApiConsumerController {
     }
 
     @PostMapping("/internal/ocr-api-request")
-    public ResponseEntity<HttpStatus> sendTestOcrApiRequest(@Valid @RequestBody OcrRequestDTO requestDTO) {
+    public ResponseEntity<HttpStatus> sendTestOcrApiRequest(@Valid @RequestBody OcrRequest requestDTO) {
         String version = System.getProperty("java.version");
         String responseId = requestDTO.getResponseId();
         LOG.debugContext(responseId, "Java version: " + version, null);

--- a/src/main/java/uk/gov/companieshouse/ocrapiconsumer/request/OcrApiConsumerController.java
+++ b/src/main/java/uk/gov/companieshouse/ocrapiconsumer/request/OcrApiConsumerController.java
@@ -5,7 +5,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.HttpServerErrorException;
@@ -15,13 +15,12 @@ import uk.gov.companieshouse.logging.LoggerFactory;
 import uk.gov.companieshouse.ocrapiconsumer.OcrApiConsumerApplication;
 import uk.gov.companieshouse.ocrapiconsumer.common.ErrorResponseDTO;
 
+import javax.validation.Valid;
+
 @RestController
 public class OcrApiConsumerController {
 
     private static final String REQUEST_ENDPOINT = "/internal/ocr-requests";
-    private static final String IMAGE_ENDPOINT_PARAMETER_NAME = "image_endpoint";
-    private static final String CONVERTED_TEXT_ENDPOINT_PARAMETER_NAME = "converted_text_endpoint";
-    private static final String RESPONSE_ID_PARAMETER_NAME = "response_id";
 
     private static final String CONTROLLER_ERROR_MESSAGE = "Unexpected error occurred";
     private static final String CLIENT_ERROR_MESSAGE = "A client error has occurred during the request";
@@ -40,24 +39,24 @@ public class OcrApiConsumerController {
      * Receives an OCR request from CHIPS and calls the service to:
      * - log it asynchronously
      * - return status code 202 (ACCEPTED)
-     * @param   imageEndpoint             The endpoint that the image is located at
-     * @param   convertedTextEndpoint     The endpoint to send the converted text to
-     * @param   responseId                The response ID of the request
-     * @return                            The HTTP Status code 202 ACCEPTED
+     * @param   requestDTO  The request details sent by CHIPS.
+     * @return              The HTTP Status code 202 ACCEPTED
      */
     @PostMapping(REQUEST_ENDPOINT)
-    public ResponseEntity<HttpStatus> receiveOcrRequest(@RequestParam(IMAGE_ENDPOINT_PARAMETER_NAME) String imageEndpoint,
-                                                        @RequestParam(CONVERTED_TEXT_ENDPOINT_PARAMETER_NAME) String convertedTextEndpoint,
-                                                        @RequestParam(RESPONSE_ID_PARAMETER_NAME) String responseId) {
+    public ResponseEntity<HttpStatus> receiveOcrRequest(@Valid @RequestBody OcrRequestDTO requestDTO) {
 
-        service.logOcrRequest(imageEndpoint, convertedTextEndpoint, responseId);
+        service.logOcrRequest(requestDTO.getImageEndpoint(),
+                requestDTO.getConvertedTextEndpoint(),
+                requestDTO.getResponseId());
         return new ResponseEntity<>(HttpStatus.ACCEPTED);
     }
 
     @PostMapping("/internal/ocr-api-request")
-    public ResponseEntity<HttpStatus> sendTestOcrApiRequest(@RequestParam(RESPONSE_ID_PARAMETER_NAME) String responseId) {
+    public ResponseEntity<HttpStatus> sendTestOcrApiRequest(@Valid @RequestBody OcrRequestDTO requestDTO) {
         String version = System.getProperty("java.version");
+        String responseId = requestDTO.getResponseId();
         LOG.debugContext(responseId, "Java version: " + version, null);
+
         service.sendOcrApiRequest(responseId);
         return new ResponseEntity<>(HttpStatus.OK);
     }

--- a/src/main/java/uk/gov/companieshouse/ocrapiconsumer/request/OcrRequest.java
+++ b/src/main/java/uk/gov/companieshouse/ocrapiconsumer/request/OcrRequest.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import javax.validation.constraints.NotBlank;
 
-public class OcrRequestDTO {
+public class OcrRequest {
 
     // Use the NotBlank annotation as each field is required and cannot be blank or null
     @NotBlank(message = "Missing required value image_endpoint")
@@ -19,7 +19,7 @@ public class OcrRequestDTO {
     @JsonProperty("response_id")
     private String responseId;
 
-    public OcrRequestDTO(String imageEndpoint, String convertedTextEndpoint, String responseId) {
+    public OcrRequest(String imageEndpoint, String convertedTextEndpoint, String responseId) {
         this.imageEndpoint = imageEndpoint;
         this.convertedTextEndpoint = convertedTextEndpoint;
         this.responseId = responseId;

--- a/src/main/java/uk/gov/companieshouse/ocrapiconsumer/request/OcrRequestDTO.java
+++ b/src/main/java/uk/gov/companieshouse/ocrapiconsumer/request/OcrRequestDTO.java
@@ -1,0 +1,51 @@
+package uk.gov.companieshouse.ocrapiconsumer.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.validation.constraints.NotBlank;
+
+public class OcrRequestDTO {
+
+    // Use the NotBlank annotation as each field is required and cannot be blank or null
+    @NotBlank(message = "Missing required value image_endpoint")
+    @JsonProperty("image_endpoint")
+    private String imageEndpoint;
+
+    @NotBlank(message = "Missing required value converted_text_endpoint")
+    @JsonProperty("converted_text_endpoint")
+    private String convertedTextEndpoint;
+
+    @NotBlank(message = "Missing required value response_id")
+    @JsonProperty("response_id")
+    private String responseId;
+
+    public OcrRequestDTO(String imageEndpoint, String convertedTextEndpoint, String responseId) {
+        this.imageEndpoint = imageEndpoint;
+        this.convertedTextEndpoint = convertedTextEndpoint;
+        this.responseId = responseId;
+    }
+
+    public String getImageEndpoint() {
+        return imageEndpoint;
+    }
+
+    public void setImageEndpoint(String imageEndpoint) {
+        this.imageEndpoint = imageEndpoint;
+    }
+
+    public String getConvertedTextEndpoint() {
+        return convertedTextEndpoint;
+    }
+
+    public void setConvertedTextEndpoint(String convertedTextEndpoint) {
+        this.convertedTextEndpoint = convertedTextEndpoint;
+    }
+
+    public String getResponseId() {
+        return responseId;
+    }
+
+    public void setResponseId(String responseId) {
+        this.responseId = responseId;
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/ocrapiconsumer/request/OcrApiConsumerControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/ocrapiconsumer/request/OcrApiConsumerControllerTest.java
@@ -26,11 +26,11 @@ class OcrApiConsumerControllerTest extends TestParent {
     void testReceiveOcrRequestReturns202() {
         // given
         ResponseEntity<HttpStatus> expected = new ResponseEntity<HttpStatus>(HttpStatus.ACCEPTED);
-        requestDTO = createMockOcrRequestDTO();
+        ocrRequest = createMockOcrRequest();
 
         // when
         ResponseEntity<HttpStatus> actual = controller
-                .receiveOcrRequest(requestDTO);
+                .receiveOcrRequest(ocrRequest);
 
         // then
         verify(service).logOcrRequest(IMAGE_ENDPOINT, CONVERTED_TEXT_ENDPOINT, RESPONSE_ID);

--- a/src/test/java/uk/gov/companieshouse/ocrapiconsumer/request/OcrApiConsumerControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/ocrapiconsumer/request/OcrApiConsumerControllerTest.java
@@ -26,10 +26,11 @@ class OcrApiConsumerControllerTest extends TestParent {
     void testReceiveOcrRequestReturns202() {
         // given
         ResponseEntity<HttpStatus> expected = new ResponseEntity<HttpStatus>(HttpStatus.ACCEPTED);
+        requestDTO = createMockOcrRequestDTO();
 
         // when
         ResponseEntity<HttpStatus> actual = controller
-                .receiveOcrRequest(IMAGE_ENDPOINT, CONVERTED_TEXT_ENDPOINT, RESPONSE_ID);
+                .receiveOcrRequest(requestDTO);
 
         // then
         verify(service).logOcrRequest(IMAGE_ENDPOINT, CONVERTED_TEXT_ENDPOINT, RESPONSE_ID);

--- a/src/test/java/uk/gov/companieshouse/ocrapiconsumer/request/TestParent.java
+++ b/src/test/java/uk/gov/companieshouse/ocrapiconsumer/request/TestParent.java
@@ -14,6 +14,7 @@ public class TestParent {
     protected static final int AVERAGE_CONFIDENCE_SCORE = 75;
     protected ExtractTextResultDTO extractTextResultDTO;
     protected ResponseEntity<ExtractTextResultDTO> response;
+    protected OcrRequestDTO requestDTO;
 
     protected ExtractTextResultDTO createMockTextResult() {
         ExtractTextResultDTO extractTextResultDTO = new ExtractTextResultDTO();
@@ -24,6 +25,11 @@ public class TestParent {
         extractTextResultDTO.setOcrProcessingTimeMs(OCR_PROCESSING_TIME);
         extractTextResultDTO.setTotalProcessingTimeMs(TOTAL_PROCESSING_TIME);
         return extractTextResultDTO;
+    }
+
+    protected OcrRequestDTO createMockOcrRequestDTO() {
+        requestDTO = new OcrRequestDTO(IMAGE_ENDPOINT, CONVERTED_TEXT_ENDPOINT, RESPONSE_ID);
+        return requestDTO;
     }
 
 }

--- a/src/test/java/uk/gov/companieshouse/ocrapiconsumer/request/TestParent.java
+++ b/src/test/java/uk/gov/companieshouse/ocrapiconsumer/request/TestParent.java
@@ -14,7 +14,7 @@ public class TestParent {
     protected static final int AVERAGE_CONFIDENCE_SCORE = 75;
     protected ExtractTextResultDTO extractTextResultDTO;
     protected ResponseEntity<ExtractTextResultDTO> response;
-    protected OcrRequestDTO requestDTO;
+    protected OcrRequest requestDTO;
 
     protected ExtractTextResultDTO createMockTextResult() {
         ExtractTextResultDTO extractTextResultDTO = new ExtractTextResultDTO();
@@ -27,8 +27,8 @@ public class TestParent {
         return extractTextResultDTO;
     }
 
-    protected OcrRequestDTO createMockOcrRequestDTO() {
-        requestDTO = new OcrRequestDTO(IMAGE_ENDPOINT, CONVERTED_TEXT_ENDPOINT, RESPONSE_ID);
+    protected OcrRequest createMockOcrRequestDTO() {
+        requestDTO = new OcrRequest(IMAGE_ENDPOINT, CONVERTED_TEXT_ENDPOINT, RESPONSE_ID);
         return requestDTO;
     }
 

--- a/src/test/java/uk/gov/companieshouse/ocrapiconsumer/request/TestParent.java
+++ b/src/test/java/uk/gov/companieshouse/ocrapiconsumer/request/TestParent.java
@@ -14,7 +14,7 @@ public class TestParent {
     protected static final int AVERAGE_CONFIDENCE_SCORE = 75;
     protected ExtractTextResultDTO extractTextResultDTO;
     protected ResponseEntity<ExtractTextResultDTO> response;
-    protected OcrRequest requestDTO;
+    protected OcrRequest ocrRequest;
 
     protected ExtractTextResultDTO createMockTextResult() {
         ExtractTextResultDTO extractTextResultDTO = new ExtractTextResultDTO();
@@ -27,9 +27,9 @@ public class TestParent {
         return extractTextResultDTO;
     }
 
-    protected OcrRequest createMockOcrRequestDTO() {
-        requestDTO = new OcrRequest(IMAGE_ENDPOINT, CONVERTED_TEXT_ENDPOINT, RESPONSE_ID);
-        return requestDTO;
+    protected OcrRequest createMockOcrRequest() {
+        ocrRequest = new OcrRequest(IMAGE_ENDPOINT, CONVERTED_TEXT_ENDPOINT, RESPONSE_ID);
+        return ocrRequest;
     }
 
 }


### PR DESCRIPTION
Refactors the controller to use RequestBody instead of RequestParam to accept the JSON message from CHIPS. Adds OcrRequest object which contains the mandatory JSON values image_endpoint, converted_text_endpoint, response_id