### PR TITLE
Fix sonar pr analysis branch from master to main

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,15 @@
 		<apache-commons-lang.version>2.6</apache-commons-lang.version>
 	</properties>
 
+	<profiles>
+		<profile>
+			<id>sonar-pr-analysis</id>
+			<properties>
+				<sonar.pullrequest.base>main</sonar.pullrequest.base>
+			</properties>
+		</profile>
+	</profiles>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
Adds a profile to the pom which points sonar-pr-analysis to main instead of master