### PR TITLE
Feature/add timeout to api call

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ OCR_API_URL                                 | The URL of the ocr-api            
 KAFKA_BROKER_ADDR                           | Address of the Kafka Broker            | localhost:9092
 CONSUMER_CONCURRENCY                        | Number of consumer threads             | 3
 RETRY_THROTTLE_RATE_SECONDS                 | Number of seconds before retrying      | 3
-OCR_REQUEST_TIMEOUT_SECONDS                 | Optional request timeout for API calls | 300
+OCR_REQUEST_TIMEOUT_SECONDS                 | Optional request timeout for API calls | 300 (default value)
 
 ## Testing Locally (dev)
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ OCR_API_URL                                 | The URL of the ocr-api            
 KAFKA_BROKER_ADDR                           | Address of the Kafka Broker                  | localhost:9092
 IS_ERROR_QUEUE_CONSUMER                     | True if an error instance of the app         | false  
 CONSUMER_CONCURRENCY                        | Number of consumer threads                   |
-OCR_REQUEST_TIMEOUT                         | Optional read timeout for API calls (millis) | 60000
+OCR_REQUEST_TIMEOUT_SECONDS                 | Optional request timeout for API calls       | 300
 
 ## Testing Locally (dev)
 

--- a/README.md
+++ b/README.md
@@ -25,12 +25,13 @@ The service can be run using docker, with the addition of the jib maven plugin.
 
 The following is a list of mandatory environment variables for the service to run:
 
-Name                                        | Description                         | Example Value
-------------------------------------------- | ----------------------------------- | -------------------------------------------------------------------------
-OCR_API_URL                                 | The URL of the ocr-api              | http://localhost:8080/api/ocr/image/tiff/extractText  (default value)
-KAFKA_BROKER_ADDR                           | Address of the Kafka Broker         | localhost:9092
-IS_ERROR_QUEUE_CONSUMER                     | True if an error instance of the app | false  
-CONSUMER_CONCURRENCY                        | Number of consumer threads          |
+Name                                        | Description                                  | Example Value
+------------------------------------------- | -----------------------------------          | -------------------------------------------------------------------------
+OCR_API_URL                                 | The URL of the ocr-api                       | http://localhost:8080/api/ocr/image/tiff/extractText  (default value)
+KAFKA_BROKER_ADDR                           | Address of the Kafka Broker                  | localhost:9092
+IS_ERROR_QUEUE_CONSUMER                     | True if an error instance of the app         | false  
+CONSUMER_CONCURRENCY                        | Number of consumer threads                   |
+OCR_REQUEST_TIMEOUT                         | Optional read timeout for API calls (millis) | 60000
 
 ## Testing Locally (dev)
 

--- a/pom.xml
+++ b/pom.xml
@@ -144,6 +144,14 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring-boot-maven-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/uk/gov/companieshouse/ocrapiconsumer/configuration/SpringConfiguration.java
+++ b/src/main/java/uk/gov/companieshouse/ocrapiconsumer/configuration/SpringConfiguration.java
@@ -3,16 +3,43 @@ package uk.gov.companieshouse.ocrapiconsumer.configuration;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
 
+import uk.gov.companieshouse.environment.EnvironmentReader;
+import uk.gov.companieshouse.environment.impl.EnvironmentReaderImpl;
 import uk.gov.companieshouse.kafka.serialization.SerializerFactory;
 
 @Configuration
 public class SpringConfiguration {
 
+    private static final int DEFAULT_REQUEST_TIMEOUT = 300_000;
+
+    private SimpleClientHttpRequestFactory getSimpleClientHttpRequestFactory() {
+        final int timeout = getTimeout();
+
+        SimpleClientHttpRequestFactory clientHttpRequestFactory
+                = new SimpleClientHttpRequestFactory();
+
+        //Connect timeout
+        clientHttpRequestFactory.setConnectTimeout(timeout);
+
+        //Read timeout
+        clientHttpRequestFactory.setReadTimeout(timeout);
+        return clientHttpRequestFactory;
+    }
+
+    private int getTimeout() {
+        final EnvironmentReader environmentReader = new EnvironmentReaderImpl();
+        Integer timeout = environmentReader.getOptionalInteger("OCR_REQUEST_TIMEOUT");
+        return timeout == null ? DEFAULT_REQUEST_TIMEOUT : timeout;
+    }
+
     @Bean
     RestTemplate restTemplate(final RestTemplateBuilder restTemplateBuilder) {
-        return restTemplateBuilder.build();
+        RestTemplate restTemplate = restTemplateBuilder.build();
+        restTemplate.setRequestFactory(getSimpleClientHttpRequestFactory());
+        return restTemplate;
     }
 
     @Bean

--- a/src/main/java/uk/gov/companieshouse/ocrapiconsumer/configuration/SpringConfiguration.java
+++ b/src/main/java/uk/gov/companieshouse/ocrapiconsumer/configuration/SpringConfiguration.java
@@ -13,8 +13,8 @@ import java.time.Duration;
 @Configuration
 public class SpringConfiguration {
 
-    private static final int DEFAULT_REQUEST_TIMEOUT_SECONDS = 300;
-    private static final String OCR_REQUEST_TIMEOUT_SECONDS = "OCR_REQUEST_TIMEOUT_SECONDS";
+    protected static final int DEFAULT_REQUEST_TIMEOUT_SECONDS = 300;
+    protected static final String OCR_REQUEST_TIMEOUT_SECONDS = "OCR_REQUEST_TIMEOUT_SECONDS";
 
     private int getTimeout(final EnvironmentReader environmentReader) {
         Integer timeout = environmentReader.getOptionalInteger(OCR_REQUEST_TIMEOUT_SECONDS);

--- a/src/main/java/uk/gov/companieshouse/ocrapiconsumer/configuration/SpringConfiguration.java
+++ b/src/main/java/uk/gov/companieshouse/ocrapiconsumer/configuration/SpringConfiguration.java
@@ -3,43 +3,34 @@ package uk.gov.companieshouse.ocrapiconsumer.configuration;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
-
 import uk.gov.companieshouse.environment.EnvironmentReader;
 import uk.gov.companieshouse.environment.impl.EnvironmentReaderImpl;
 import uk.gov.companieshouse.kafka.serialization.SerializerFactory;
+
+import java.time.Duration;
 
 @Configuration
 public class SpringConfiguration {
 
     private static final int DEFAULT_REQUEST_TIMEOUT = 300_000;
 
-    private SimpleClientHttpRequestFactory getSimpleClientHttpRequestFactory() {
-        final int timeout = getTimeout();
-
-        SimpleClientHttpRequestFactory clientHttpRequestFactory
-                = new SimpleClientHttpRequestFactory();
-
-        //Connect timeout
-        clientHttpRequestFactory.setConnectTimeout(timeout);
-
-        //Read timeout
-        clientHttpRequestFactory.setReadTimeout(timeout);
-        return clientHttpRequestFactory;
-    }
-
-    private int getTimeout() {
-        final EnvironmentReader environmentReader = new EnvironmentReaderImpl();
+    private int getTimeout(final EnvironmentReader environmentReader) {
         Integer timeout = environmentReader.getOptionalInteger("OCR_REQUEST_TIMEOUT");
         return timeout == null ? DEFAULT_REQUEST_TIMEOUT : timeout;
     }
 
     @Bean
-    RestTemplate restTemplate(final RestTemplateBuilder restTemplateBuilder) {
-        RestTemplate restTemplate = restTemplateBuilder.build();
-        restTemplate.setRequestFactory(getSimpleClientHttpRequestFactory());
-        return restTemplate;
+    EnvironmentReader environmentReader() {
+        return new EnvironmentReaderImpl();
+    }
+
+    @Bean
+    RestTemplate restTemplate(final RestTemplateBuilder restTemplateBuilder,
+                              final EnvironmentReader environmentReader) {
+        return restTemplateBuilder
+                .setReadTimeout(Duration.ofMillis(getTimeout(environmentReader)))
+                .build();
     }
 
     @Bean

--- a/src/main/java/uk/gov/companieshouse/ocrapiconsumer/configuration/SpringConfiguration.java
+++ b/src/main/java/uk/gov/companieshouse/ocrapiconsumer/configuration/SpringConfiguration.java
@@ -13,11 +13,12 @@ import java.time.Duration;
 @Configuration
 public class SpringConfiguration {
 
-    private static final int DEFAULT_REQUEST_TIMEOUT = 300_000;
+    private static final int DEFAULT_REQUEST_TIMEOUT_SECONDS = 300;
+    private static final String OCR_REQUEST_TIMEOUT_SECONDS = "OCR_REQUEST_TIMEOUT_SECONDS";
 
     private int getTimeout(final EnvironmentReader environmentReader) {
-        Integer timeout = environmentReader.getOptionalInteger("OCR_REQUEST_TIMEOUT");
-        return timeout == null ? DEFAULT_REQUEST_TIMEOUT : timeout;
+        Integer timeout = environmentReader.getOptionalInteger(OCR_REQUEST_TIMEOUT_SECONDS);
+        return timeout == null ? DEFAULT_REQUEST_TIMEOUT_SECONDS : timeout;
     }
 
     @Bean
@@ -28,8 +29,10 @@ public class SpringConfiguration {
     @Bean
     RestTemplate restTemplate(final RestTemplateBuilder restTemplateBuilder,
                               final EnvironmentReader environmentReader) {
+        Duration timeoutInSeconds = Duration.ofSeconds(getTimeout(environmentReader));
         return restTemplateBuilder
-                .setReadTimeout(Duration.ofMillis(getTimeout(environmentReader)))
+                .setConnectTimeout(timeoutInSeconds)
+                .setReadTimeout(timeoutInSeconds)
                 .build();
     }
 

--- a/src/main/java/uk/gov/companieshouse/ocrapiconsumer/request/OcrRequest.java
+++ b/src/main/java/uk/gov/companieshouse/ocrapiconsumer/request/OcrRequest.java
@@ -19,6 +19,10 @@ public class OcrRequest {
     @JsonProperty("response_id")
     private String responseId;
 
+    public OcrRequest() {
+
+    }
+
     public OcrRequest(String imageEndpoint, String convertedTextEndpoint, String responseId) {
         this.imageEndpoint = imageEndpoint;
         this.convertedTextEndpoint = convertedTextEndpoint;

--- a/src/test/java/uk/gov/companieshouse/ocrapiconsumer/configuration/RestTemplateTimeoutConfigurationTest.java
+++ b/src/test/java/uk/gov/companieshouse/ocrapiconsumer/configuration/RestTemplateTimeoutConfigurationTest.java
@@ -1,0 +1,79 @@
+package uk.gov.companieshouse.ocrapiconsumer.configuration;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.web.client.RestTemplate;
+import uk.gov.companieshouse.environment.EnvironmentReader;
+
+import java.time.Duration;
+
+@ExtendWith(MockitoExtension.class)
+class RestTemplateTimeoutConfigurationTest {
+
+    private static final int DEFAULT_REQUEST_TIMEOUT = 300_000;
+    private static final Integer MOCK_TIMEOUT = 60_000;
+    private static final String OCR_REQUEST_TIMEOUT = "OCR_REQUEST_TIMEOUT";
+
+    @Mock
+    private RestTemplateBuilder mockRestTemplateBuilder;
+
+    @Mock
+    private EnvironmentReader environmentReader;
+
+    @InjectMocks
+    private SpringConfiguration springConfiguration;
+
+    @Captor
+    private ArgumentCaptor<Duration> timeout;
+
+    @Test
+    void testReadTimeoutEnvVariableUsed() {
+        //given
+        Duration expected = Duration.ofMillis(MOCK_TIMEOUT);
+        doReturn(MOCK_TIMEOUT).when(environmentReader).getOptionalInteger(OCR_REQUEST_TIMEOUT);
+        doReturn(mockRestTemplateBuilder).when(mockRestTemplateBuilder).setReadTimeout(any());
+        doReturn(new RestTemplate()).when(mockRestTemplateBuilder).build();
+
+        // when
+        RestTemplate restTemplate = springConfiguration.restTemplate(mockRestTemplateBuilder, environmentReader);
+
+        // then
+        verify(environmentReader, times(1)).getOptionalInteger(OCR_REQUEST_TIMEOUT);
+        verify(mockRestTemplateBuilder).setReadTimeout(timeout.capture());
+        Duration actual = timeout.getValue();
+        assertThat(actual, is(expected));
+
+    }
+
+    @Test
+    void testReadTimeoutDefaultUsed() {
+        // given
+        Duration expected = Duration.ofMillis(DEFAULT_REQUEST_TIMEOUT);
+        doReturn(null).when(environmentReader).getOptionalInteger(OCR_REQUEST_TIMEOUT);
+        doReturn(mockRestTemplateBuilder).when(mockRestTemplateBuilder).setReadTimeout(any());
+        doReturn(new RestTemplate()).when(mockRestTemplateBuilder).build();
+
+        // when
+        RestTemplate restTemplate = springConfiguration.restTemplate(mockRestTemplateBuilder, environmentReader);
+
+        // then
+        verify(mockRestTemplateBuilder).setReadTimeout(timeout.capture());
+        verify(environmentReader, times(1)).getOptionalInteger(OCR_REQUEST_TIMEOUT);
+        Duration actual = timeout.getValue();
+        assertThat(actual, is(expected));
+
+    }
+
+}

--- a/src/test/java/uk/gov/companieshouse/ocrapiconsumer/configuration/RestTemplateTimeoutConfigurationTest.java
+++ b/src/test/java/uk/gov/companieshouse/ocrapiconsumer/configuration/RestTemplateTimeoutConfigurationTest.java
@@ -5,6 +5,8 @@ import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static uk.gov.companieshouse.ocrapiconsumer.configuration.SpringConfiguration.DEFAULT_REQUEST_TIMEOUT_SECONDS;
+import static uk.gov.companieshouse.ocrapiconsumer.configuration.SpringConfiguration.OCR_REQUEST_TIMEOUT_SECONDS;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -21,9 +23,7 @@ import java.time.Duration;
 @ExtendWith(MockitoExtension.class)
 class RestTemplateTimeoutConfigurationTest {
 
-    private static final int DEFAULT_REQUEST_TIMEOUT_SECONDS = 300;
     private static final Integer MOCK_TIMEOUT_SECONDS = 60;
-    private static final String OCR_REQUEST_TIMEOUT_SECONDS = "OCR_REQUEST_TIMEOUT_SECONDS";
 
     @Mock
     private RestTemplateBuilder mockRestTemplateBuilder;

--- a/src/test/java/uk/gov/companieshouse/ocrapiconsumer/configuration/RestTemplateTimeoutConfigurationTest.java
+++ b/src/test/java/uk/gov/companieshouse/ocrapiconsumer/configuration/RestTemplateTimeoutConfigurationTest.java
@@ -2,7 +2,6 @@ package uk.gov.companieshouse.ocrapiconsumer.configuration;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -22,9 +21,9 @@ import java.time.Duration;
 @ExtendWith(MockitoExtension.class)
 class RestTemplateTimeoutConfigurationTest {
 
-    private static final int DEFAULT_REQUEST_TIMEOUT = 300_000;
-    private static final Integer MOCK_TIMEOUT = 60_000;
-    private static final String OCR_REQUEST_TIMEOUT = "OCR_REQUEST_TIMEOUT";
+    private static final int DEFAULT_REQUEST_TIMEOUT_SECONDS = 300;
+    private static final Integer MOCK_TIMEOUT_SECONDS = 60;
+    private static final String OCR_REQUEST_TIMEOUT_SECONDS = "OCR_REQUEST_TIMEOUT_SECONDS";
 
     @Mock
     private RestTemplateBuilder mockRestTemplateBuilder;
@@ -41,16 +40,19 @@ class RestTemplateTimeoutConfigurationTest {
     @Test
     void testReadTimeoutEnvVariableUsed() {
         //given
-        Duration expected = Duration.ofMillis(MOCK_TIMEOUT);
-        doReturn(MOCK_TIMEOUT).when(environmentReader).getOptionalInteger(OCR_REQUEST_TIMEOUT);
-        doReturn(mockRestTemplateBuilder).when(mockRestTemplateBuilder).setReadTimeout(any());
+        Duration expected = Duration.ofSeconds(MOCK_TIMEOUT_SECONDS);
+        doReturn(MOCK_TIMEOUT_SECONDS).when(environmentReader).getOptionalInteger(OCR_REQUEST_TIMEOUT_SECONDS);
+        doReturn(mockRestTemplateBuilder).when(mockRestTemplateBuilder)
+                .setReadTimeout(Duration.ofSeconds(MOCK_TIMEOUT_SECONDS));
+        doReturn(mockRestTemplateBuilder).when(mockRestTemplateBuilder)
+                .setConnectTimeout(Duration.ofSeconds(MOCK_TIMEOUT_SECONDS));
         doReturn(new RestTemplate()).when(mockRestTemplateBuilder).build();
 
         // when
         RestTemplate restTemplate = springConfiguration.restTemplate(mockRestTemplateBuilder, environmentReader);
 
         // then
-        verify(environmentReader, times(1)).getOptionalInteger(OCR_REQUEST_TIMEOUT);
+        verify(environmentReader, times(1)).getOptionalInteger(OCR_REQUEST_TIMEOUT_SECONDS);
         verify(mockRestTemplateBuilder).setReadTimeout(timeout.capture());
         Duration actual = timeout.getValue();
         assertThat(actual, is(expected));
@@ -60,9 +62,12 @@ class RestTemplateTimeoutConfigurationTest {
     @Test
     void testReadTimeoutDefaultUsed() {
         // given
-        Duration expected = Duration.ofMillis(DEFAULT_REQUEST_TIMEOUT);
-        doReturn(null).when(environmentReader).getOptionalInteger(OCR_REQUEST_TIMEOUT);
-        doReturn(mockRestTemplateBuilder).when(mockRestTemplateBuilder).setReadTimeout(any());
+        Duration expected = Duration.ofSeconds(DEFAULT_REQUEST_TIMEOUT_SECONDS);
+        doReturn(null).when(environmentReader).getOptionalInteger(OCR_REQUEST_TIMEOUT_SECONDS);
+        doReturn(mockRestTemplateBuilder).when(mockRestTemplateBuilder)
+                .setReadTimeout(Duration.ofSeconds(DEFAULT_REQUEST_TIMEOUT_SECONDS));
+        doReturn(mockRestTemplateBuilder).when(mockRestTemplateBuilder)
+                .setConnectTimeout(Duration.ofSeconds(DEFAULT_REQUEST_TIMEOUT_SECONDS));
         doReturn(new RestTemplate()).when(mockRestTemplateBuilder).build();
 
         // when
@@ -70,7 +75,7 @@ class RestTemplateTimeoutConfigurationTest {
 
         // then
         verify(mockRestTemplateBuilder).setReadTimeout(timeout.capture());
-        verify(environmentReader, times(1)).getOptionalInteger(OCR_REQUEST_TIMEOUT);
+        verify(environmentReader, times(1)).getOptionalInteger(OCR_REQUEST_TIMEOUT_SECONDS);
         Duration actual = timeout.getValue();
         assertThat(actual, is(expected));
 


### PR DESCRIPTION
Add configurable request timeout to RestTemplate calls.
This adds a request timeout for API RestTemplate calls with a default of 5 minutes (300,000 millis). This can be configured through an environment variable 'OCR_REQUEST_TIMEOUT'. 

Resolves: IVP-1276.