### PR TITLE
Improve consumer concurrency

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,14 @@ The service can be run using docker, with the addition of the jib maven plugin.
 
 The following is a list of mandatory environment variables for the service to run:
 
-Name                                        | Description                            | Example Value
-------------------------------------------- | ------------------------------------   | -------------------------------------------------------------------------
-OCR_API_URL                                 | The URL of the ocr-api                 | `http://localhost:8080/api/ocr/image/tiff/extractText`
-KAFKA_BROKER_ADDR                           | Address of the Kafka Broker            | localhost:9092
-CONSUMER_CONCURRENCY                        | Number of consumer threads             | 3
-RETRY_THROTTLE_RATE_SECONDS                 | Number of seconds before retrying      | 3
-OCR_REQUEST_TIMEOUT_SECONDS                 | Optional request timeout for API calls | 300 (default value)
+Name                                        | Description                                 | Example Value
+------------------------------------------- | ------------------------------------------- | -------------------------------------------------------------------------
+OCR_API_URL                                 | The URL of the ocr-api                      | `http://localhost:8080/api/ocr/image/tiff/extractText`
+KAFKA_BROKER_ADDR                           | Address of the Kafka Broker                 | localhost:9092
+CONSUMER_CONCURRENCY                        | Number of consumer threads for main topic   | 3
+CONSUMER_CONCURRENCY_RETRY                  | Number of consumer threads for retry topic  | 1 (default value)
+RETRY_THROTTLE_RATE_SECONDS                 | Number of seconds before retrying           | 3
+OCR_REQUEST_TIMEOUT_SECONDS                 | Optional request timeout for API calls      | 300 (default value)
 
 ## Testing Locally (dev)
 

--- a/src/main/java/uk/gov/companieshouse/ocrapiconsumer/configuration/KafkaConfig.java
+++ b/src/main/java/uk/gov/companieshouse/ocrapiconsumer/configuration/KafkaConfig.java
@@ -45,7 +45,6 @@ public class KafkaConfig {
         ConcurrentKafkaListenerContainerFactory<String, OcrRequestMessage> factory = new ConcurrentKafkaListenerContainerFactory<>();
 
         factory.setConsumerFactory(consumerFactory(environmentReader));
-        factory.setConcurrency(getConcurrency(environmentReader));
 
         return factory;
     }
@@ -61,10 +60,6 @@ public class KafkaConfig {
         props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
 
         return props;
-    }
-
-    private Integer getConcurrency(final EnvironmentReader environmentReader) {
-        return environmentReader.getMandatoryInteger(EnvironmentVariable.CONSUMER_CONCURRENCY.name());
     }
 
     private String getBootstrapServers(final EnvironmentReader environmentReader) {

--- a/src/main/java/uk/gov/companieshouse/ocrapiconsumer/request/ExtractTextResultDTO.java
+++ b/src/main/java/uk/gov/companieshouse/ocrapiconsumer/request/ExtractTextResultDTO.java
@@ -1,6 +1,6 @@
 package uk.gov.companieshouse.ocrapiconsumer.request;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -127,12 +127,12 @@ public class ExtractTextResultDTO {
 
     public Map<String,Object>  metadataMap() {
 
-        Map<String,Object> map = new HashMap<>();
+        Map<String,Object> map = new LinkedHashMap<>();
 
-        map.put("lowestConfidenceScore", lowestConfidenceScore);
-        map.put("averageConfidenceScore", averageConfidenceScore);
-        map.put("ocrProcessingTimeMs", ocrProcessingTimeMs);
-        map.put("totalProcessingTimeMs", totalProcessingTimeMs);
+        map.put("lowest_confidence_score", lowestConfidenceScore);
+        map.put("average_confidence_score", averageConfidenceScore);
+        map.put("ocr_processing_time_ms", ocrProcessingTimeMs);
+        map.put("total_processing_time_ms", totalProcessingTimeMs);
         map.put("response_id", responseId);
         map.put("context_id", contextId);
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,3 +2,6 @@
 max.poll.interval.ms=600000
 
 server.port=9090
+
+kafka.consumer.main.topic.concurrency=${CONSUMER_CONCURRENCY}
+kafka.consumer.retry.topic.concurrency=${CONSUMER_CONCURRENCY_RETRY:1}


### PR DESCRIPTION
Jira IVP-1114

Rather than have one value for concurrency in the Kafka Consumer, moved this to the Kafka Listeners so we can have different values for both the main and retry topic.

Used spring application properties for these (rather than environmental reader) since this is required for the configuration to work on the @KafkaListener annotation.

Improved logging when processing messages from the topic