### PR TITLE
Correct Kafka Commit processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Name                                        | Description                       
 OCR_API_URL                                 | The URL of the ocr-api                            | http://localhost:8080/api/ocr/image/tiff/extractText
 KAFKA_BROKER_ADDR                           | Address of the Kafka Broker                       | localhost:9092
 KAFKA_MAX_POLL_INTERVAL_MS                  | The interval for Kafka polling in milliseconds    | 10000
+KAFKA_MAX_POLL_RECORDS                      | Number of records Kafka gets in a Poll            | 1
 CONSUMER_CONCURRENCY                        | Number of consumer threads                        | 3
 CONSUMER_CONCURRENCY_RETRY                  | Number of consumer threads for retry topic        | 1 (default value)
 RETRY_THROTTLE_RATE_SECONDS                 | Number of seconds before retrying                 | 3

--- a/README.md
+++ b/README.md
@@ -4,7 +4,16 @@ Service to consume requests for extraction of text from images and manage the re
 
 When this application starts up it will consume messages on both the Main and Retry Topic.
 
-There is no error topic processing so far since all clients require this data in a timely manner and so errors need to be sent back to the calling system in this case
+There is no error topic processing since all clients require this data in a timely manner and so errors are sent back to the calling system directly in the client callback method.
+
+With this Kafka consumer we want to explicitly commit each Kafka message after we have finished processing it (i.e. sent results back to the client that sent the original `ocr-request` message). This is done by as described in [Fault-tolerant and reliable messaging with Kafka and Spring Boot](https://arnoldgalovics.com/fault-tolerant-and-reliable-messaging-with-kafka-and-spring-boot/):
+
+- using manual commits
+- using acknowledge mode of MANUAL_IMMEDIATE
+- adding an `Acknowledgement` parameter in the @KafkaListener consume methods
+- calling `acknowledgment.acknowledge()` after the results of the `ocr-request` have been sent back to the client system (either successful or in error)
+
+A difference with this Kafka consumers to most others in CH is that processing of each method takes significantly longer (rather than sub second it takes over a minute) since it blocks on a call to the `ocr-api` which does an image to text conversion (this itself will take over a minute for a 20 page articles of association). Therefore the number of records Kafka reads on each poll is made a configurable parameter using the KAFKA_MAX_POLL_RECORDS environmental variable.
 
 ## Requirements
 

--- a/src/main/java/uk/gov/companieshouse/ocrapiconsumer/configuration/KafkaConfig.java
+++ b/src/main/java/uk/gov/companieshouse/ocrapiconsumer/configuration/KafkaConfig.java
@@ -10,6 +10,7 @@ import org.springframework.kafka.annotation.EnableKafka;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.listener.ContainerProperties;
 import org.springframework.kafka.support.LogIfLevelEnabled;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
@@ -30,6 +31,8 @@ public class KafkaConfig {
 
     private int maxPollIntervalMs;
 
+    private int maxPollRecords;
+
     @Autowired
     private final SpringConfiguration springConfiguration;
 
@@ -40,6 +43,7 @@ public class KafkaConfig {
 
         bootstrapServers = this.springConfiguration.getKafkaBroker();
         maxPollIntervalMs = this.springConfiguration.getMaxPollIntervalMs();       
+        maxPollRecords = this.springConfiguration.getMaxPollRecords();
     }
 
     @Bean
@@ -58,6 +62,7 @@ public class KafkaConfig {
 
         factory.setConsumerFactory(consumerFactory());
         factory.getContainerProperties().setCommitLogLevel(LogIfLevelEnabled.Level.INFO);
+        factory.getContainerProperties().setAckMode(ContainerProperties.AckMode.MANUAL_IMMEDIATE);
 
         return factory;
     }
@@ -72,6 +77,7 @@ public class KafkaConfig {
         props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false);
         props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
         props.put(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, maxPollIntervalMs);
+        props.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, maxPollRecords);
 
         return props;
     }

--- a/src/main/java/uk/gov/companieshouse/ocrapiconsumer/configuration/SpringConfiguration.java
+++ b/src/main/java/uk/gov/companieshouse/ocrapiconsumer/configuration/SpringConfiguration.java
@@ -52,6 +52,9 @@ public class SpringConfiguration {
     @Value("${kafka.consumer.max.poll.interval.ms}")
     private int maxPollIntervalMs;
 
+	@Value("${kafka.consumer.max.poll.records}")
+	private int maxPollRecords;
+
     @Value("${ocr.request.timeout.seconds}")
     protected int ocrRequestTimeoutSeconds;
 
@@ -92,6 +95,10 @@ public class SpringConfiguration {
         return maxPollIntervalMs;
     }
 
+	public int getMaxPollRecords() {
+        return maxPollRecords;
+    }
+
 
     @Bean
     RestTemplate restTemplate(final RestTemplateBuilder restTemplateBuilder) {
@@ -123,6 +130,7 @@ public class SpringConfiguration {
 		LOG.info("The value of ${kafka.retry.throttle.rate.second} is :         " + kafkaRetryThrottleRateSeconds);
 		LOG.info("The value of ${kafka.bootstrap-servers} is :                  " + kafkaBroker);
 		LOG.info("The value of ${kafka.consumer.max.poll.interval.ms} is :      " + maxPollIntervalMs);
+		LOG.info("The value of ${kafka.consumer.max.poll.records} is :          " + maxPollRecords);
 
 		LOG.info("-------------------- End displaying Environment variables defined in spring application.properties  ----------------------------------");
 	}

--- a/src/main/java/uk/gov/companieshouse/ocrapiconsumer/kafka/OcrApiConsumerKafkaConsumer.java
+++ b/src/main/java/uk/gov/companieshouse/ocrapiconsumer/kafka/OcrApiConsumerKafkaConsumer.java
@@ -78,6 +78,9 @@ public class OcrApiConsumerKafkaConsumer {
         try {
             handleOcrRequestMessage(message, metadata.topic());
         }
+        catch (Exception e) {
+            LOG.errorContext("Unexpected Exception on Main Consumer", e, null);
+        }
         finally {
             acknowledgment.acknowledge();
             LOG.debugContext(contextFromMessage(message), "Offset committed", null);
@@ -98,6 +101,9 @@ public class OcrApiConsumerKafkaConsumer {
 
         try {
             handleOcrRequestMessage(message, metadata.topic());
+        }
+        catch (Exception e) {
+            LOG.errorContext("Unexpected Exception on Retry Consumer", e, null);
         }
         finally {
             acknowledgment.acknowledge();

--- a/src/main/java/uk/gov/companieshouse/ocrapiconsumer/kafka/OcrApiConsumerKafkaConsumer.java
+++ b/src/main/java/uk/gov/companieshouse/ocrapiconsumer/kafka/OcrApiConsumerKafkaConsumer.java
@@ -81,9 +81,12 @@ public class OcrApiConsumerKafkaConsumer {
         catch (Exception e) {
             LOG.errorContext("Unexpected Exception on Main Consumer", e, null);
         }
+        catch (Error er) {
+            LOG.errorContext("Unexpected Error on Main Consumer " + er.getMessage(), new Exception("Unexpected Error on Main Consumer"), null);
+        }
         finally {
             acknowledgment.acknowledge();
-            LOG.debugContext(contextFromMessage(message), "Offset committed", null);
+            LOG.infoContext(contextFromMessage(message), "Offset committed", null);
         }
     }
 
@@ -105,9 +108,12 @@ public class OcrApiConsumerKafkaConsumer {
         catch (Exception e) {
             LOG.errorContext("Unexpected Exception on Retry Consumer", e, null);
         }
+        catch (Error er) {
+            LOG.errorContext("Unexpected Error on Retry Consumer " + er.getMessage(), new Exception("Unexpected Error on Retry Consumer"), null);
+        }
         finally {
             acknowledgment.acknowledge();
-            LOG.debugContext(contextFromMessage(message), "Offset committed", null);
+            LOG.infoContext(contextFromMessage(message), "Offset committed", null);
         }
     }
 

--- a/src/main/java/uk/gov/companieshouse/ocrapiconsumer/kafka/OcrApiConsumerKafkaConsumer.java
+++ b/src/main/java/uk/gov/companieshouse/ocrapiconsumer/kafka/OcrApiConsumerKafkaConsumer.java
@@ -75,9 +75,13 @@ public class OcrApiConsumerKafkaConsumer {
 
         logConsumeKafkaMessage(message.getPayload(), metadata);
 
-        handleOcrRequestMessage(message, metadata.topic());
-
-        acknowledgment.acknowledge();
+        try {
+            handleOcrRequestMessage(message, metadata.topic());
+        }
+        finally {
+            acknowledgment.acknowledge();
+            LOG.debugContext(contextFromMessage(message), "Offset committed", null);
+        }
     }
 
     @KafkaListener(
@@ -92,9 +96,18 @@ public class OcrApiConsumerKafkaConsumer {
 
         delayRetry(message.getPayload().getContextId());
 
-        handleOcrRequestMessage(message, metadata.topic());
+        try {
+            handleOcrRequestMessage(message, metadata.topic());
+        }
+        finally {
+            acknowledgment.acknowledge();
+            LOG.debugContext(contextFromMessage(message), "Offset committed", null);
+        }
+    }
 
-        acknowledgment.acknowledge();
+    private String contextFromMessage(org.springframework.messaging.Message<OcrRequestMessage> message) {
+        OcrRequestMessage ocrRequestMessage = message.getPayload();
+        return ocrRequestMessage.getContextId();
     }
 
     private void handleOcrRequestMessage(org.springframework.messaging.Message<OcrRequestMessage> message,

--- a/src/main/java/uk/gov/companieshouse/ocrapiconsumer/request/OcrApiConsumerService.java
+++ b/src/main/java/uk/gov/companieshouse/ocrapiconsumer/request/OcrApiConsumerService.java
@@ -9,6 +9,7 @@ import uk.gov.companieshouse.logging.LoggerFactory;
 import uk.gov.companieshouse.ocr.OcrRequestMessage;
 import uk.gov.companieshouse.ocrapiconsumer.OcrApiConsumerApplication;
 
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 @Service
@@ -49,7 +50,7 @@ public class OcrApiConsumerService {
         LOG.debugContext(ocrRequestDTO.getContextId(), "Getting the TIFF image", null);
         byte[] image = getImageContents(ocrRequestDTO);
 
-        LOG.debugContext(ocrRequestDTO.getContextId(), "Sending image to ocr microservice for conversion", null);
+        LOG.debugContext(ocrRequestDTO.getContextId(), "Sending image to ocr microservice for conversion", imageLogMap(image));
 
         ResponseEntity<ExtractTextResultDTO> response
                 = sendRequestToOcrMicroservice(ocrRequestDTO.getContextId(), image, ocrRequestDTO.getResponseId());
@@ -66,6 +67,15 @@ public class OcrApiConsumerService {
         sendTextResult(ocrRequestDTO, extractedText);
     }
 
+
+    private Map<String, Object> imageLogMap(byte[] image) {
+
+        Map<String,Object> map = new LinkedHashMap<>();
+
+        map.put("image_length", image.length);
+  
+        return map;
+    }
 
     private byte[] getImageContents(OcrRequestDTO ocrRequestDTO) {
         return imageRestClient.getImageContentsFromEndpoint(ocrRequestDTO.getContextId(), ocrRequestDTO.getImageEndpoint());

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,3 +14,5 @@ kafka.consumer.retry.topic.concurrency=${CONSUMER_CONCURRENCY_RETRY:1}
 kafka.retry.throttle.rate.seconds=${RETRY_THROTTLE_RATE_SECONDS}
 kafka.bootstrap-servers=${KAFKA_BROKER_ADDR}
 kafka.consumer.max.poll.interval.ms=${KAFKA_MAX_POLL_INTERVAL_MS}
+kafka.consumer.max.poll.records=${KAFKA_MAX_POLL_RECORDS}
+

--- a/src/test/java/uk/gov/companieshouse/ocrapiconsumer/kafka/OcrApiConsumerKafkaConsumerTest.java
+++ b/src/test/java/uk/gov/companieshouse/ocrapiconsumer/kafka/OcrApiConsumerKafkaConsumerTest.java
@@ -81,6 +81,7 @@ class OcrApiConsumerKafkaConsumerTest {
 
         // Then
         verify(ocrApiConsumerService).ocrRequest(message.getPayload());
+        verify(acknowledgment).acknowledge();
     }
 
 
@@ -103,6 +104,7 @@ class OcrApiConsumerKafkaConsumerTest {
 
         // Then
         verify(kafkaProducer).sendMessage(any());
+        verify(acknowledgment).acknowledge();
     }
 
     @Test
@@ -123,6 +125,7 @@ class OcrApiConsumerKafkaConsumerTest {
         // Then
         assertTrue(watch.getTime() > (RETRY_THROTTLE_RATE_SECONDS * 1000));
         verify(ocrApiConsumerService).ocrRequest(message.getPayload());
+        verify(acknowledgment).acknowledge();
     }
 
     // Test that we re-try a message when we get a RetryableErrorException
@@ -145,7 +148,7 @@ class OcrApiConsumerKafkaConsumerTest {
 
         // Then
         verify(kafkaProducer).sendMessage(any());
-
+        verify(acknowledgment).acknowledge();
     }
 
     @Test
@@ -165,6 +168,7 @@ class OcrApiConsumerKafkaConsumerTest {
         // Then
         verify(kafkaProducer, never()).sendMessage(any());
         verify(ocrMessageErrorHandler).handleMaximumRetriesException(any(), any(), any(), any());
+        verify(acknowledgment).acknowledge();
     }
 
     @Test
@@ -185,6 +189,7 @@ class OcrApiConsumerKafkaConsumerTest {
         // Then
         verify(kafkaProducer, never()).sendMessage(any());
         verify(ocrMessageErrorHandler).generalException(any(), any(), any(), any());
+        verify(acknowledgment).acknowledge();
     }
 
     private RetryableErrorException newRetryableError() {

--- a/src/test/java/uk/gov/companieshouse/ocrapiconsumer/kafka/OcrApiConsumerKafkaConsumerTest.java
+++ b/src/test/java/uk/gov/companieshouse/ocrapiconsumer/kafka/OcrApiConsumerKafkaConsumerTest.java
@@ -17,6 +17,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.kafka.listener.adapter.ConsumerRecordMetadata;
+import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.messaging.MessageHeaders;
 import uk.gov.companieshouse.kafka.exceptions.SerializationException;
 import uk.gov.companieshouse.kafka.serialization.AvroSerializer;
@@ -42,6 +43,8 @@ class OcrApiConsumerKafkaConsumerTest {
 
     private static final int MAXIMUM_RETRY_ATTEMPTS = 3;
 
+    @Mock
+    private Acknowledgment acknowledgment;
     @Mock
     private SerializerFactory serializerFactory;
     @Mock
@@ -74,7 +77,7 @@ class OcrApiConsumerKafkaConsumerTest {
         org.springframework.messaging.Message<OcrRequestMessage> message = createTestMessage(kafkaConsumer.getMainTopicName(), 0);
 
         // When
-        kafkaConsumer.consumeOcrApiRequestMessage(message, metadataWithTopic(kafkaConsumer.getMainTopicName()));
+        kafkaConsumer.consumeOcrApiRequestMessage(message, metadataWithTopic(kafkaConsumer.getMainTopicName()), acknowledgment);
 
         // Then
         verify(ocrApiConsumerService).ocrRequest(message.getPayload());
@@ -96,7 +99,7 @@ class OcrApiConsumerKafkaConsumerTest {
         when(serializer.toBinary(any())).thenReturn(new byte[4]);
 
         // When
-        kafkaConsumer.consumeOcrApiRequestMessage(message, metadataWithTopic(kafkaConsumer.getMainTopicName()));
+        kafkaConsumer.consumeOcrApiRequestMessage(message, metadataWithTopic(kafkaConsumer.getMainTopicName()), acknowledgment);
 
         // Then
         verify(kafkaProducer).sendMessage(any());
@@ -113,7 +116,7 @@ class OcrApiConsumerKafkaConsumerTest {
         watch.start();
 
         // When
-        kafkaConsumer.consumeOcrApiRequestRetryMessage(message, metadataWithTopic(kafkaConsumer.getRetryTopicName()));
+        kafkaConsumer.consumeOcrApiRequestRetryMessage(message, metadataWithTopic(kafkaConsumer.getRetryTopicName()), acknowledgment);
 
         watch.stop();
 
@@ -138,7 +141,7 @@ class OcrApiConsumerKafkaConsumerTest {
         when(serializer.toBinary(any())).thenReturn(new byte[4]);
 
         // When
-        kafkaConsumer.consumeOcrApiRequestRetryMessage(message, metadataWithTopic(kafkaConsumer.getRetryTopicName()));
+        kafkaConsumer.consumeOcrApiRequestRetryMessage(message, metadataWithTopic(kafkaConsumer.getRetryTopicName()), acknowledgment);
 
         // Then
         verify(kafkaProducer).sendMessage(any());
@@ -157,7 +160,7 @@ class OcrApiConsumerKafkaConsumerTest {
         doThrow(newRetryableError()).when(ocrApiConsumerService).ocrRequest(message.getPayload());
 
         // When
-        kafkaConsumer.consumeOcrApiRequestRetryMessage(message, metadataWithTopic(kafkaConsumer.getRetryTopicName()));
+        kafkaConsumer.consumeOcrApiRequestRetryMessage(message, metadataWithTopic(kafkaConsumer.getRetryTopicName()), acknowledgment);
 
         // Then
         verify(kafkaProducer, never()).sendMessage(any());
@@ -177,7 +180,7 @@ class OcrApiConsumerKafkaConsumerTest {
                 .when(ocrApiConsumerService).ocrRequest(message.getPayload());
 
         // When
-        kafkaConsumer.consumeOcrApiRequestRetryMessage(message, metadataWithTopic(kafkaConsumer.getRetryTopicName()));
+        kafkaConsumer.consumeOcrApiRequestRetryMessage(message, metadataWithTopic(kafkaConsumer.getRetryTopicName()), acknowledgment);
 
         // Then
         verify(kafkaProducer, never()).sendMessage(any());


### PR DESCRIPTION
Jira: IVP-1479

With this Kafka consumer we want to explicitly commit each Kafka message after we have finished processing it (i.e. sent results back to the client that sent the original `ocr-request` message). This is done by as described in [Fault-tolerant and reliable messaging with Kafka and Spring Boot](https://arnoldgalovics.com/fault-tolerant-and-reliable-messaging-with-kafka-and-spring-boot/):

- using manual commits
- using acknowledge mode of MANUAL_IMMEDIATE
- adding an `Acknowledgement` parameter in the @KafkaListener consume methods
- calling `acknowledgment.acknowledge()` after the results of the `ocr-request` have been sent back to the client system (either successful or in error)

A difference with this Kafka consumers to most others in CH is that processing of each method takes significantly longer (rather than sub second it takes over a minute) since it blocks on a call to the `ocr-api` which does an image to text conversion (this itself will take over a minute for a 20 page articles of association). Therefore the number of records Kafka reads on each poll is made a configurable parameter using the KAFKA_MAX_POLL_RECORDS environmental variable.

In the main listen methods (Main and Retry topics) I added some extra catches so we could get the logging information in live just incase something very unexpected happened

Also now log at info level for when the Spring Kafka library does the Commiting.